### PR TITLE
Updating dependencies to support Wicket 7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
         <mvn.build.java.version>1.7</mvn.build.java.version>
         <mvn.version>3.0.0</mvn.version>
 
-        <wicket.version>6.13.0</wicket.version>
-        <wicket-webjars.version>0.4.1</wicket-webjars.version>
+        <wicket.version>7.0.0</wicket.version>
+        <wicket-webjars.version>0.5.3</wicket-webjars.version>
         <stacktrace-js.version>0.5.0</stacktrace-js.version>
         <amplify-js.version>1.1.0</amplify-js.version>
 


### PR DESCRIPTION
Required change to support the new version of Wicket and Wicket-webjars.